### PR TITLE
examples: thresholder removal

### DIFF
--- a/beard/similarity/pairs.py
+++ b/beard/similarity/pairs.py
@@ -331,7 +331,7 @@ class ElementMultiplication(TransformerMixin):
 
 
 class Thresholder(TransformerMixin):
-    """Element-wise multiplication on paired data."""
+    """Element-wise floating number binarization."""
 
     def __init__(self, threshold):
         """Initialize.

--- a/examples/applications/author-disambiguation/distance.py
+++ b/examples/applications/author-disambiguation/distance.py
@@ -264,8 +264,7 @@ def _build_distance_estimator(X, y, verbose=0, ethnicity_estimator=None,
                 ("classifier", EstimatorTransformer(ethnicity_estimator)),
             ]), groupby=group_by_signature)),
             ("sigmoid", FuncTransformer(func=expit)),
-            ("combiner", ElementMultiplication()),
-            ("thresholder", Thresholder(0.25))
+            ("combiner", ElementMultiplication())
         ])))
 
     # Train a classifier on these vectors


### PR DESCRIPTION
As the Thresholder is not longer needed, it is removed from the exemplary disambiguation.

Signed-off-by: Mateusz Susik <mateuszsusik@gmail.com>