### PR TITLE
utils: fix IndexError in given_name_initial

### DIFF
--- a/beard/utils/names.py
+++ b/beard/utils/names.py
@@ -232,7 +232,10 @@ def given_name_initial(name, index=0):
             # For example "John Smith", without comma. The first string should
             # indicate the first given name.
             asciified = asciify(split_name[0]).lower().strip()
-            return RE_CHARACTERS.findall(asciified)[0]
+            try:
+                return RE_CHARACTERS.findall(asciified)[0]
+            except IndexError:
+                pass
         return ""
 
 


### PR DESCRIPTION
Fixes `given_name_initial(name, index=0)` by returning empty string in case of `IndexError: list index out of range`. This exception is caused by having invalid author names, e.g. `name='., '`. Unfortunately, we have such names on CDS.