### PR TITLE
Add nysiis python 3 support

### DIFF
--- a/beard/__init__.py
+++ b/beard/__init__.py
@@ -9,4 +9,4 @@
 
 """Bibliographic Entity Automatic Recognition and Disambiguation."""
 
-__version__ = "0.2"
+__version__ = "0.2.1"

--- a/examples/applications/author-disambiguation/clustering.py
+++ b/examples/applications/author-disambiguation/clustering.py
@@ -23,7 +23,10 @@ import numpy as np
 
 from functools import partial
 
-from sklearn.cross_validation import train_test_split
+try:
+    from sklearn.cross_validation import train_test_split
+except ImportError:
+    from sklearn.model_selection import train_test_split
 
 # These imports are used during unpickling.
 from utils import get_author_full_name

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ _keywords = [
 ]
 
 _install_requires = [
-    "jellyfish",
+    # jellyfish 0.7 is Python 3 only
+    "jellyfish<=0.7",
     "numpy>=1.9",
     "scipy>=0.14",
     "scikit-learn>=0.15.2",

--- a/setup.py
+++ b/setup.py
@@ -92,9 +92,11 @@ _install_requires = [
 ]
 
 if sys.version[0] == '2':
-    # fuzzy package is not available on Python 3
-    # version 1.1 due to Soundex bug in 1.2
+    # use version 1.1 due to Soundex bug in 1.2
     _install_requires.append("fuzzy==1.1")
+else:
+    # need to use version 1.2 with buggy Soundex for Python 3 compatibility
+    _install_requires.append("fuzzy~=1.0,>=1.2")
 
 _tests_require = [
     "coverage",

--- a/tests/similarity/test_pairs.py
+++ b/tests/similarity/test_pairs.py
@@ -22,7 +22,10 @@ import scipy.sparse as sp
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.preprocessing import StandardScaler
-from sklearn.cross_validation import train_test_split
+try:
+    from sklearn.cross_validation import train_test_split
+except ImportError:
+    from sklearn.model_selection import train_test_split
 from sklearn.datasets import load_iris
 from sklearn.svm import LinearSVC
 

--- a/tests/utils/test_names.py
+++ b/tests/utils/test_names.py
@@ -17,6 +17,8 @@
 import pytest
 import sys
 
+import fuzzy
+
 from beard.ext.metaphone import dm
 
 from beard.utils.names import phonetic_tokenize_name
@@ -87,14 +89,15 @@ def test_phonetic_tokenize_name_simple():
         phonetic_tokenize_name("Dupont, Jean")
 
 
-@pytest.mark.skipif(sys.version[0] == '3',
-                    reason="fuzzy package doesn't work with Python 3")
-def test_phonetic_tokenize_name_python2():
-    """Test checking if custom phonetic algorithms from fuzzy packages work."""
-    import fuzzy
-    soundex = fuzzy.Soundex(5)
+def test_phonetic_tokenize_name_nysiis():
     assert phonetic_tokenize_name("Dupont, René", "nysiis") == (
         ((fuzzy.nysiis(u"Dupont"),), (fuzzy.nysiis(u"René"),)))
+
+
+@pytest.mark.xfail(reason="soundex is broken in fuzzy 1.2.*")
+def test_phonetic_tokenize_name_soundex():
+    """Test checking if custom phonetic algorithms from fuzzy packages work."""
+    soundex = fuzzy.Soundex(5)
     assert phonetic_tokenize_name("Dupont, René", "soundex") == (
         # no direct support for unicode in soundex, thus "Rene"
         ((soundex(u"Dupont"),), (soundex(u"Rene"),)))


### PR DESCRIPTION
Several algorithms can be used for phonetic blocking. The fuzzy library provides all of them, but has a bug in v1.2.* (see https://github.com/yougov/fuzzy/issues/14) that prevents soundex from working correctly. Unfortunately, that's the only version compatible with Python 3. Previously, version 1.1 was used on Python 2 and an alternative implementation of double metaphone was used on Python 3, so soundex and NYSIIS were not available. Now we install version 1.1 on Python 2 and 1.2.* on Python 3, resulting in NYSIIS being always available also (this happens to be the algorithm giving the best results).

## To summarize

Before:

|Algorithm|Python 2|Python3|
|------------|-----------|-----------|
|soundex| :heavy_check_mark: | :negative_squared_cross_mark:|
|NYSIIS| :heavy_check_mark: | :negative_squared_cross_mark:|
|double metaphone|  :heavy_check_mark: | :heavy_check_mark:|

After:

|Algorithm|Python 2|Python3|
|------------|-----------|-----------|
|soundex| :heavy_check_mark: | :negative_squared_cross_mark:|
|NYSIIS| :heavy_check_mark: | :heavy_check_mark:|
|double metaphone|  :heavy_check_mark: | :heavy_check_mark:|
